### PR TITLE
Fix wireless settings group value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ wpa_ascii=
 wmm=0
 ```
 
-* Properties which can be set using `/adm/set_group.cgi?group=NETWORK&$property=$value`.
+* Properties which can be set using `/adm/set_group.cgi?group=WIRELESS&$property=$value`.
     * `wlan_type`   Valid values are 
         * `0` Ad hoc
         * `1` Infrastructure 


### PR DESCRIPTION
The wireless settings are set in the WIRELESS group, which is separate from the NETWORK group.

I believe there is a typo around line 744 relating the command to set the wireless settings.  Currently the line is: `/adm/set_group.cgi?group=NETWORK&$property=$value`.  But this returns an error on Iris Sercomm RC8221 cameras.  By changing `NETWORK` to `WIRELESS` the commands complete successfully.
-A